### PR TITLE
Implement Unsafe Cell for interior mutability

### DIFF
--- a/benches/intersection.rs
+++ b/benches/intersection.rs
@@ -147,6 +147,22 @@ fn site_positions(c: &mut Criterion) {
     });
 }
 
+fn state_modify_basis(c: &mut Criterion) {
+    let state = create_packed_state(256);
+    let mut basis = state.generate_basis();
+
+    c.bench_function("Modify Basis", |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                for value in basis.iter_mut() {
+                    value.set_value(value.get_value() + 0.1);
+                    value.reset_value();
+                }
+            }
+        })
+    });
+}
+
 criterion_group!(
     intersections,
     shape_check_intersection,
@@ -154,4 +170,7 @@ criterion_group!(
     state_check_intersection,
     site_positions,
 );
-criterion_main!(intersections);
+
+criterion_group!(general, site_positions, state_modify_basis,);
+
+criterion_main!(intersections, general);

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,13 +265,12 @@ fn analyse_state(
         })
         // Final optimsation to help find the minimum
         .map(|(index, opt_state)| {
-            let result = optimiser
+            optimiser
                 .clone()
                 .kt_start(0.)
                 .seed(index)
                 .build()
-                .optimise_state(opt_state);
-            result
+                .optimise_state(opt_state)
         })
         .max();
 

--- a/src/optimisation.rs
+++ b/src/optimisation.rs
@@ -138,7 +138,7 @@ impl MCOptimiser {
         }
     }
 
-    pub fn optimise_state(&self, mut state: impl State) -> impl State {
+    pub fn optimise_state(&self, state: impl State) -> impl State {
         let mut score_current = match state.score() {
             Ok(score) => score,
             _ => panic!("Invalid configuration passed to function, exiting."),

--- a/src/state/packed.rs
+++ b/src/state/packed.rs
@@ -92,10 +92,10 @@ where
         }
     }
 
-    fn generate_basis(&mut self) -> Vec<StandardBasis> {
+    fn generate_basis(&self) -> Vec<StandardBasis> {
         let mut basis: Vec<StandardBasis> = vec![];
         basis.append(&mut self.cell.get_degrees_of_freedom());
-        for site in self.occupied_sites.iter_mut() {
+        for site in self.occupied_sites.iter() {
             basis.append(&mut site.get_basis(1));
         }
         basis

--- a/src/state/potential.rs
+++ b/src/state/potential.rs
@@ -77,10 +77,10 @@ where
     C: Cell,
     T: Site,
 {
-    fn generate_basis(&mut self) -> Vec<StandardBasis> {
+    fn generate_basis(&self) -> Vec<StandardBasis> {
         let mut basis: Vec<StandardBasis> = vec![];
         basis.append(&mut self.cell.get_degrees_of_freedom());
-        for site in self.occupied_sites.iter_mut() {
+        for site in self.occupied_sites.iter() {
             basis.append(&mut site.get_basis(1));
         }
         basis

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,7 +93,7 @@ pub trait Cell:
     fn from_family(group: CrystalFamily, max_size: f64) -> Self;
     fn to_cartesian_isometry(&self, transform: &Transform2) -> Transform2;
     fn to_cartesian_point(&self, point: Vector2<f64>) -> Vector2<f64>;
-    fn get_degrees_of_freedom(&mut self) -> Vec<StandardBasis>;
+    fn get_degrees_of_freedom(&self) -> Vec<StandardBasis>;
     fn center(&self) -> Vector2<f64>;
     fn area(&self) -> f64;
     fn get_corners(&self) -> Vec<Vector2<f64>>;
@@ -104,7 +104,7 @@ pub trait Site: Clone + Send + Sync + Serialize + fmt::Debug {
     fn positions<'a>(&'a self) -> Box<dyn Iterator<Item = Transform2> + 'a>;
     fn multiplicity(&self) -> usize;
     fn from_wyckoff(wyckoff: &WyckoffSite) -> Self;
-    fn get_basis(&mut self, rot_symmetry: u64) -> Vec<StandardBasis>;
+    fn get_basis(&self, rot_symmetry: u64) -> Vec<StandardBasis>;
 }
 
 pub trait State:
@@ -120,7 +120,7 @@ pub trait State:
     + ToSVG<Value = Document>
 {
     fn score(&self) -> Result<f64, &'static str>;
-    fn generate_basis(&mut self) -> Vec<StandardBasis>;
+    fn generate_basis(&self) -> Vec<StandardBasis>;
     fn total_shapes(&self) -> usize;
     fn as_positions(&self) -> Result<String, fmt::Error>;
 }


### PR DESCRIPTION
This provides a more appropriate approach to interior mutability using an approach which is suitable for this use case.

It is also reasonably straightforward to switch out this implementation for another.

Fixes #23 