### PR TITLE
chore(ci): Run security audit on dependency update

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,16 @@
+name: Security audit
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '@monthly'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,8 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   schedule:
-    - cron: '@monthly'
+    # Schedule to run at 05:05 on the 5th of every month
+    - cron: '5 5 5 * *'
 jobs:
   security_audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that none of the dependencies have security advisories
whenever the dependencies are updated and additionally every month.