### PR TITLE
refactor: Convert Transform struct to use nalgebra

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -115,7 +115,7 @@ impl Cell2 {
     /// and converts the values of the fractional coordinates in the translation to real
     /// Cartesian coordinates based on the current cell parameters.
     ///
-    pub fn to_cartesian_isometry(&self, transform: &Transform2) -> Transform2 {
+    pub fn to_cartesian_isometry(&self, transform: Transform2) -> Transform2 {
         transform.set_position(self.to_cartesian_point(transform.position()))
     }
 
@@ -217,7 +217,7 @@ impl Cell2 {
     ) -> impl Iterator<Item = Transform2> + 'a {
         iproduct!(-shells..=shells, -shells..=shells)
             .filter(move |&(x, y)| !(!zero && x == 0 && y == 0))
-            .map(move |(x, y)| self.to_cartesian_translate(&transform, x, y))
+            .map(move |(x, y)| self.to_cartesian_translate(transform, x, y))
     }
 
     pub fn get_corners(&self) -> Vec<Point2<f64>> {
@@ -234,8 +234,8 @@ impl Cell2 {
             .collect()
     }
 
-    pub fn to_cartesian_translate(&self, transform: &Transform2, x: i64, y: i64) -> Transform2 {
-        let position = Point2::from(transform.position());
+    pub fn to_cartesian_translate(&self, transform: Transform2, x: i64, y: i64) -> Transform2 {
+        let position = transform.position();
         transform
             .set_position(self.to_cartesian_point(Translation2::new(x as f64, y as f64) * position))
     }
@@ -278,14 +278,14 @@ mod cell_tests {
         let cell = Cell2::default();
         let trans = Transform2::new(0., (0.5, 0.5));
 
-        assert_eq!(cell.to_cartesian_isometry(&trans), trans);
+        assert_eq!(cell.to_cartesian_isometry(trans), trans);
 
         cell.angle.set_value(PI / 4.);
         let expected = Transform2::new(
             0.,
             (0.5 + 0.5 * 1. / f64::sqrt(2.), 0.5 * 1. / f64::sqrt(2.)),
         );
-        assert_abs_diff_eq!(cell.to_cartesian_isometry(&trans), expected);
+        assert_abs_diff_eq!(cell.to_cartesian_isometry(trans), expected);
     }
 
     #[test]

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -116,7 +116,7 @@ impl Cell2 {
     /// Cartesian coordinates based on the current cell parameters.
     ///
     pub fn to_cartesian_isometry(&self, transform: &Transform2) -> Transform2 {
-        transform.set_position(self.to_cartesian_point(transform.position().into()).coords)
+        transform.set_position(self.to_cartesian_point(transform.position()))
     }
 
     /// Convert a point in relative coordinates to real coordinates
@@ -236,10 +236,8 @@ impl Cell2 {
 
     pub fn to_cartesian_translate(&self, transform: &Transform2, x: i64, y: i64) -> Transform2 {
         let position = Point2::from(transform.position());
-        transform.set_position(
-            self.to_cartesian_point(Translation2::new(x as f64, y as f64) * position)
-                .coords,
-        )
+        transform
+            .set_position(self.to_cartesian_point(Translation2::new(x as f64, y as f64) * position))
     }
 
     /// Convert two values in relative coordinates to real coordinates
@@ -265,7 +263,6 @@ impl Cell2 {
 mod cell_tests {
     use approx::assert_abs_diff_eq;
     use itertools::izip;
-    use nalgebra::Vector2;
 
     use super::*;
 
@@ -333,14 +330,14 @@ mod cell_tests {
     #[test]
     fn periodic_images_nozero() {
         let translations = vec![
-            Vector2::new(-1., -1.),
-            Vector2::new(-1., 0.),
-            Vector2::new(-1., 1.),
-            Vector2::new(0., -1.),
-            Vector2::new(0., 1.),
-            Vector2::new(1., -1.),
-            Vector2::new(1., -0.),
-            Vector2::new(1., 1.),
+            Point2::new(-1., -1.),
+            Point2::new(-1., 0.),
+            Point2::new(-1., 1.),
+            Point2::new(0., -1.),
+            Point2::new(0., 1.),
+            Point2::new(1., -1.),
+            Point2::new(1., -0.),
+            Point2::new(1., 1.),
         ];
         let cell = Cell2::default();
         let transform = Transform2::identity();
@@ -353,15 +350,15 @@ mod cell_tests {
     #[test]
     fn periodic_images() {
         let translations = vec![
-            Vector2::new(-1., -1.),
-            Vector2::new(-1., 0.),
-            Vector2::new(-1., 1.),
-            Vector2::new(0., -1.),
-            Vector2::new(0., 0.),
-            Vector2::new(0., 1.),
-            Vector2::new(1., -1.),
-            Vector2::new(1., -0.),
-            Vector2::new(1., 1.),
+            Point2::new(-1., -1.),
+            Point2::new(-1., 0.),
+            Point2::new(-1., 1.),
+            Point2::new(0., -1.),
+            Point2::new(0., 0.),
+            Point2::new(0., 1.),
+            Point2::new(1., -1.),
+            Point2::new(1., -0.),
+            Point2::new(1., 1.),
         ];
         let cell = Cell2::default();
         let transform = Transform2::identity();

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,10 +133,12 @@ fn analyse_state(
         .max()
         .ok_or_else(|| anyhow!("Error in running optimisation."))?;
 
-    let final_score = final_state
-        .score()
-        .ok_or_else(|| anyhow!("State has become corrupted"))?;
-    info!("Final score: {}", final_score);
+    info!(
+        "Final score: {}",
+        final_state
+            .score()
+            .ok_or_else(|| anyhow!("State has become corrupted"))?
+    );
 
     let serialised = serde_json::to_string(&final_state)?;
 

--- a/src/site.rs
+++ b/src/site.rs
@@ -42,7 +42,7 @@ impl OccupiedSite {
     pub fn positions<'a>(&'a self) -> impl Iterator<Item = Transform2> + 'a {
         let transform = self.transform();
         self.symmetries()
-            .map(move |sym| sym * &transform)
+            .map(move |sym| sym * transform)
             .map(|sym| sym.periodic(1., -0.5))
     }
 

--- a/src/state/packed.rs
+++ b/src/state/packed.rs
@@ -111,7 +111,7 @@ where
 {
     pub fn cartesian_positions<'a>(&'a self) -> impl Iterator<Item = Transform2> + 'a {
         self.relative_positions()
-            .map(move |position| self.cell.to_cartesian_isometry(&position))
+            .map(move |position| self.cell.to_cartesian_isometry(position))
     }
 
     pub fn relative_positions<'a>(&'a self) -> impl Iterator<Item = Transform2> + 'a {
@@ -189,7 +189,7 @@ where
     }
 
     pub fn from_group(shape: S, group: &WallpaperGroup) -> Result<Self, Error> {
-        let wallpaper = Wallpaper::new(&group);
+        let wallpaper = Wallpaper::new(group);
         let isopointal = &[WyckoffSite::new(group)?];
         Ok(Self::initialise(shape, wallpaper, isopointal))
     }

--- a/src/state/potential.rs
+++ b/src/state/potential.rs
@@ -138,7 +138,7 @@ where
 {
     pub fn cartesian_positions<'a>(&'a self) -> impl Iterator<Item = Transform2> + 'a {
         self.relative_positions()
-            .map(move |position| self.cell.to_cartesian_isometry(&position))
+            .map(move |position| self.cell.to_cartesian_isometry(position))
     }
 
     pub fn relative_positions<'a>(&'a self) -> impl Iterator<Item = Transform2> + 'a {
@@ -146,7 +146,7 @@ where
     }
 
     pub fn from_group(shape: S, group: &WallpaperGroup) -> Result<Self, Error> {
-        let wallpaper = Wallpaper::new(&group);
+        let wallpaper = Wallpaper::new(group);
         let isopointal = &[WyckoffSite::new(group)?];
         Ok(Self::initialise(shape, wallpaper, isopointal))
     }

--- a/src/to_svg.rs
+++ b/src/to_svg.rs
@@ -155,7 +155,7 @@ where
         }
 
         for position in self.relative_positions() {
-            let transform = self.cell.to_cartesian_isometry(&position);
+            let transform = self.cell.to_cartesian_isometry(position);
             doc = doc.add(transform.as_svg().set("href", "#mol").set("fill", "blue"));
             for periodic in self.cell.periodic_images(position, 1, false) {
                 doc = doc.add(periodic.as_svg().set("href", "#mol").set("fill", "green"));
@@ -195,7 +195,7 @@ where
             doc = doc.add(transform.as_svg().set("href", "#cell"));
         }
         for position in self.relative_positions() {
-            let matrix = self.cell.to_cartesian_isometry(&position);
+            let matrix = self.cell.to_cartesian_isometry(position);
             doc = doc.add(matrix.as_svg().set("href", "#mol").set("fill", "blue"));
             for transform in self.cell.periodic_images(position, 1, false) {
                 doc = doc.add(transform.as_svg().set("href", "#mol").set("fill", "green"));

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -9,7 +9,7 @@ use std::ops::Mul;
 
 #[cfg(test)]
 use approx::AbsDiffEq;
-use nalgebra::{Matrix3, Point2, Vector2, Vector3};
+use nalgebra::{Matrix3, Point2, Translation2};
 use serde::{Deserialize, Serialize};
 
 /// Perform coordinate tranforms on a point in space
@@ -31,17 +31,17 @@ use serde::{Deserialize, Serialize};
 /// angular rotation being the first argument, and the translation being the second argument.
 ///
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct Transform2(Matrix3<f64>);
+pub struct Transform2(nalgebra::Transform2<f64>);
 
 impl From<Matrix3<f64>> for Transform2 {
     fn from(matrix: Matrix3<f64>) -> Self {
-        Self(matrix)
+        Self(nalgebra::Transform2::from_matrix_unchecked(matrix))
     }
 }
 
 impl Into<Matrix3<f64>> for Transform2 {
     fn into(self) -> Matrix3<f64> {
-        self.0
+        *self.0.matrix()
     }
 }
 
@@ -62,17 +62,7 @@ binop_impl_all!(
     Mul, mul;
     self: Transform2, rhs: Point2<f64>, Output = Point2<f64>;
     [ref ref] => {
-        let result = self.0 * rhs.to_homogeneous();
-        Point2::from(result.xy())
-    };
-);
-
-binop_impl_all!(
-    Mul, mul;
-    self: Transform2, rhs: Vector2<f64>, Output = Vector2<f64>;
-    [ref ref] => {
-        let result = self.0 * Vector3::new(rhs.x, rhs.y, 1.);
-        result.xy()
+        self.0 * rhs
     };
 );
 
@@ -80,38 +70,36 @@ binop_impl_all!(
     Mul, mul;
     self: Transform2, rhs: Transform2, Output = Transform2;
     [ref ref] => {
-        Transform2::from(self.0 * rhs.0)
+        Transform2(self.0 * rhs.0)
     };
 );
 
 impl Transform2 {
     pub fn new(rotation: f64, translation: (f64, f64)) -> Transform2 {
-        Transform2::from(Matrix3::new(
-            rotation.cos(),
-            -rotation.sin(),
-            translation.0,
-            rotation.sin(),
-            rotation.cos(),
-            translation.1,
-            0.,
-            0.,
-            1.,
+        let translation = nalgebra::Translation2::new(translation.0, translation.1);
+        let rotation = nalgebra::Rotation2::new(rotation);
+        Transform2(nalgebra::Transform2::from_matrix_unchecked(
+            nalgebra::IsometryMatrix2::from_parts(translation, rotation).to_homogeneous(),
         ))
     }
 
     pub fn identity() -> Self {
-        Self(Matrix3::identity())
+        Self(nalgebra::Transform2::identity())
     }
 
-    pub fn position(&self) -> Vector2<f64> {
-        Vector2::new(self.0[(0, 2)], self.0[(1, 2)])
+    pub fn position(&self) -> Point2<f64> {
+        self.0 * Point2::origin()
     }
 
-    pub fn set_position(&self, position: Vector2<f64>) -> Transform2 {
-        let mut transform = self.clone();
-        transform.0[(0, 2)] = position.x;
-        transform.0[(1, 2)] = position.y;
-        transform
+    pub fn get_translation(&self) -> Translation2<f64> {
+        Translation2::new(self.0.matrix()[(0, 2)], self.0.matrix()[(1, 2)])
+    }
+
+    pub fn set_position(&self, position: Point2<f64>) -> Transform2 {
+        let mut transform = self.0.clone();
+        transform[(0, 2)] = position.x;
+        transform[(1, 2)] = position.y;
+        Transform2(transform)
     }
 
     pub fn periodic(&self, period: f64, offset: f64) -> Transform2 {
@@ -212,13 +200,13 @@ mod test {
     #[quickcheck]
     fn new_translation(x: f64, y: f64) -> bool {
         let t = Transform2::new(0., (x, y));
-        t.position() == Vector2::new(x, y)
+        t.position() == Point2::new(x, y)
     }
 
     /// Check get position is same as set
     #[quickcheck]
     fn set_get_translation(x: f64, y: f64) -> bool {
-        let pos = Vector2::new(x, y);
+        let pos = Point2::new(x, y);
         let t = Transform2::identity().set_position(pos);
         t.position() == pos
     }
@@ -231,7 +219,7 @@ mod test {
         #[quickcheck]
         fn identity_transform(x: f64, y: f64) -> bool {
             let identity = Transform2::identity();
-            let point = Vector2::new(x, y);
+            let point = Point2::new(x, y);
             identity * point == point
         }
 
@@ -239,28 +227,28 @@ mod test {
         #[quickcheck]
         fn rotation_length(angle: f64) -> bool {
             let t = Transform2::new(angle, (0., 0.));
-            let point = Vector2::new(1., 0.);
-            abs_diff_eq!((t * point).norm(), 1.)
+            let point = Point2::new(1., 0.);
+            abs_diff_eq!(nalgebra::distance(&Point2::origin(), &(t * point)), 1.)
         }
 
         /// Translation from origin puts point in same location
         #[quickcheck]
         fn translation_from_origin(x: f64, y: f64) -> bool {
             let t = &Transform2::new(0., (x, y));
-            let origin = Vector2::zeros();
-            t * origin == t.position()
+            t * Point2::origin() == t.position()
         }
 
         /// Rotation followed by Translation is in circle about translation
         #[quickcheck]
         fn rotation_translation(rotation: f64, translation: (f64, f64)) -> bool {
             let t = &Transform2::new(rotation, translation);
-            let point = Vector2::new(1., 0.);
+            let point = Point2::new(1., 0.);
             abs_diff_eq!(
-                (t * point - t.position()).norm(),
+                nalgebra::distance(&Point2::origin(), &(t * point - t.position()).into()),
                 1.,
                 // Large transformations will have larger errors which this accounts for
-                epsilon = t.position().norm() * Transform2::default_epsilon()
+                epsilon = nalgebra::distance(&Point2::origin(), &t.position())
+                    * Transform2::default_epsilon()
             )
         }
     }
@@ -273,7 +261,7 @@ mod test {
         #[quickcheck]
         fn mult_transform_translation(x: f64, y: f64) -> bool {
             let t = &Transform2::new(0., (x, y));
-            abs_diff_eq!((t * t).position(), 2. * Vector2::new(x, y))
+            abs_diff_eq!((t * t).position(), 2. * Point2::new(x, y))
         }
 
         /// Translations should be added
@@ -281,7 +269,10 @@ mod test {
         fn mult_transform_translations(t1: (f64, f64), t2: (f64, f64)) -> bool {
             let tf1 = &Transform2::new(0., t1);
             let tf2 = &Transform2::new(0., t2);
-            abs_diff_eq!((tf1 * tf2).position(), tf1.position() + tf2.position())
+            abs_diff_eq!(
+                (tf1 * tf2).position(),
+                tf1.get_translation() * tf2.position()
+            )
         }
 
         /// Translations and rotations independent if translation multiplied first
@@ -297,7 +288,7 @@ mod test {
         fn rotate_translation(rotation: f64, translation: (f64, f64)) -> bool {
             let tf1 = &Transform2::new(rotation, (0., 0.));
             let tf2 = &Transform2::new(0., translation);
-            let rotated = tf1 * Vector2::new(translation.0, translation.1);
+            let rotated = tf1 * Point2::new(translation.0, translation.1);
             abs_diff_eq!(tf1 * tf2, Transform2::new(rotation, (rotated.x, rotated.y)))
         }
 
@@ -306,7 +297,6 @@ mod test {
         fn combine_rotations(r1: f64, r2: f64) -> bool {
             let tf1 = &Transform2::new(r1, (0., 0.));
             let tf2 = &Transform2::new(r2, (0., 0.));
-            dbg!((tf1 * tf2).0 - Transform2::new(r1 + r2, (0., 0.)).0);
             abs_diff_eq!(
                 tf1 * tf2,
                 Transform2::new(r1 + r2, (0., 0.)),
@@ -326,7 +316,7 @@ mod test {
         #[quickcheck]
         fn rotation_and_trans(rotation: f64, translation: (f64, f64)) -> bool {
             let t = &Transform2::new(rotation, translation);
-            let position = t * Vector2::new(translation.0, translation.1);
+            let position = t * Point2::new(translation.0, translation.1);
             // dbg!(position);
             println!("rotation: {}, translation: {:?}", rotation, translation);
             dbg!(
@@ -334,7 +324,6 @@ mod test {
                 position,
                 Transform2::new(rotation * 2., (position.x, position.y)).0
             );
-            dbg!((t * t).0 - Transform2::new(rotation * 2., (position.x, position.y)).0);
             abs_diff_eq!(
                 t * t,
                 Transform2::new(rotation + rotation, (position.x, position.y)),
@@ -346,7 +335,7 @@ mod test {
         fn rotation_and_trans_different(r1: f64, r2: f64, t1: (f64, f64), t2: (f64, f64)) -> bool {
             let tf1 = &Transform2::new(r1, t1);
             let tf2 = &Transform2::new(r2, t2);
-            let position = tf1 * Vector2::new(t2.0, t2.1);
+            let position = tf1 * Point2::new(t2.0, t2.1);
             println!("r1: {}, r2: {}, t1: {:?}, t2: {:?}", r1, r2, t1, t2);
             dbg!(
                 (tf1 * tf2).0,
@@ -373,7 +362,7 @@ mod test {
                 na::UnitComplex::new(r2),
             );
 
-            abs_diff_eq!((tf1 * tf2).0, (ntf1 * ntf2).to_homogeneous())
+            abs_diff_eq!((tf1 * tf2).0.matrix(), &(ntf1 * ntf2).to_homogeneous())
         }
     }
 
@@ -381,48 +370,48 @@ mod test {
     fn transform() {
         let t = Transform2::new(f64::consts::PI / 2., (1., 1.));
 
-        let point = Vector2::new(0.2, 0.2);
-        assert_eq!(t * point, Vector2::new(0.8, 1.2));
+        let point = Point2::new(0.2, 0.2);
+        assert_eq!(t * point, Point2::new(0.8, 1.2));
     }
 
     #[test]
     fn parse_operation_default() {
         let input = String::from("(x, y)");
         let st = Transform2::from_operations(&input).unwrap();
-        let point = Vector2::new(0.1, 0.2);
-        assert_abs_diff_eq!(st * point, Vector2::new(0.1, 0.2));
+        let point = Point2::new(0.1, 0.2);
+        assert_abs_diff_eq!(st * point, Point2::new(0.1, 0.2));
     }
 
     #[test]
     fn parse_operation_xy() {
         let input = String::from("(-x, x+y)");
         let st = Transform2::from_operations(&input).unwrap();
-        let point = Vector2::new(0.1, 0.2);
-        assert_abs_diff_eq!(st * point, Vector2::new(-0.1, 0.3));
+        let point = Point2::new(0.1, 0.2);
+        assert_abs_diff_eq!(st * point, Point2::new(-0.1, 0.3));
     }
 
     #[test]
     fn parse_operation_consts() {
         let input = String::from("(x+1/2, -y)");
         let st = Transform2::from_operations(&input).unwrap();
-        let point = Vector2::new(0.1, 0.2);
-        assert_abs_diff_eq!(st * point, Vector2::new(0.6, -0.2));
+        let point = Point2::new(0.1, 0.2);
+        assert_abs_diff_eq!(st * point, Point2::new(0.6, -0.2));
     }
 
     #[test]
     fn parse_operation_neg_consts() {
         let input = String::from("(x-1/2, -y)");
         let st = Transform2::from_operations(&input).unwrap();
-        let point = Vector2::new(0.1, 0.2);
-        assert_abs_diff_eq!(st * point, Vector2::new(-0.4, -0.2));
+        let point = Point2::new(0.1, 0.2);
+        assert_abs_diff_eq!(st * point, Point2::new(-0.4, -0.2));
     }
 
     #[test]
     fn parse_operation_zero_const() {
         let input = String::from("(-y, 0)");
         let st = Transform2::from_operations(&input).unwrap();
-        let point = Vector2::new(0.1, 0.2);
-        assert_abs_diff_eq!(st * point, Vector2::new(-0.2, 0.));
+        let point = Point2::new(0.1, 0.2);
+        assert_abs_diff_eq!(st * point, Point2::new(-0.2, 0.));
     }
 
     #[test]

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// The order of rotation, followed by translation is followed in the initialisation, with the
 /// angular rotation being the first argument, and the translation being the second argument.
 ///
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Transform2(nalgebra::Transform2<f64>);
 
 impl From<Matrix3<f64>> for Transform2 {
@@ -95,11 +95,10 @@ impl Transform2 {
         Translation2::new(self.0.matrix()[(0, 2)], self.0.matrix()[(1, 2)])
     }
 
-    pub fn set_position(&self, position: Point2<f64>) -> Transform2 {
-        let mut transform = self.0.clone();
-        transform[(0, 2)] = position.x;
-        transform[(1, 2)] = position.y;
-        Transform2(transform)
+    pub fn set_position(mut self, position: Point2<f64>) -> Transform2 {
+        self.0[(0, 2)] = position.x;
+        self.0[(1, 2)] = position.y;
+        self
     }
 
     pub fn periodic(&self, period: f64, offset: f64) -> Transform2 {


### PR DESCRIPTION
The Transform2 struct which I have defined is now a wrapper around the
nalgebra::Transform2 struct. The idea is that my struct may not be
necessary.